### PR TITLE
Exclude home subdirs from `isRootHomeOrSystemPath`

### DIFF
--- a/extensions/auto-mode/hard-deny.ts
+++ b/extensions/auto-mode/hard-deny.ts
@@ -170,6 +170,7 @@ function isRootHomeOrSystemPath(path: string): boolean {
     "/usr",
     "/var",
   ];
+  if (path.startsWith(`${HOME}/`)) return false;
   return (
     path === "/" ||
     path === HOME ||


### PR DESCRIPTION
Hi, I'm trying to use this package on Bluefin (Fedora Silverblue-based, with `HOME` under `/var`, e.g. `/var/home/jdoe`) and I'm hitting an over-broad hard-deny.

When the agent runs a recursive `rm` on any path under the user's home (e.g. `rm -rf /var/home/jdoe/projects/foobar/build`), `isRootHomeOrSystemPath` in `extensions/auto-mode/hard-deny.ts` returns `true` and the command is unconditionally denied with "irreversible deletion of home/root/system paths is hard-denied".

https://github.com/czottmann/pi-automode/blob/87c047bc85261920394bd11a7e7830adcf2082ac/extensions/auto-mode/hard-deny.ts#L159-L178

The `path === HOME` check is correct. The over-match comes from the system-roots branch: `/var` is in `systemRoots`, and `path.startsWith("/var/")` swallows the whole `HOME` subtree on distros where HOME lives under `/var`.

The PR implements a minimal fix: exempt HOME's own subtree before checking system roots. This preserves `path === HOME` (still blocks `rm -rf ~`), keeps `/var/log`, `/etc`, etc. protected, and only stops the rule from swallowing `~/...` on `/var/home` distros.