### PR TITLE
fix(status): add space after AM indicator; add statusStyle setting to reduce noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Set a global default classifier model in `~/.pi/agent/automode.json`; override i
 
 The setting follows the normal scalar precedence: global, then project-local, then `PI_AUTOMODE_SETTINGS_JSON`. Shared project `.pi/automode.json` cannot set it. Omitting the key at a higher-precedence scope does not clear a lower-precedence value.
 
+`statusStyle` controls the status line verbosity. `"full"` (default) always shows action counters: `AM ● a:5 d:1`. `"minimal"` shows `AM ●` alone until the first action is checked or blocked, then shows counters. This reduces startup noise while preserving the diagnostic signal when denials occur.
+
 Example:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set a global default classifier model in `~/.pi/agent/automode.json`; override i
 
 The setting follows the normal scalar precedence: global, then project-local, then `PI_AUTOMODE_SETTINGS_JSON`. Shared project `.pi/automode.json` cannot set it. Omitting the key at a higher-precedence scope does not clear a lower-precedence value.
 
-`statusStyle` controls the status line verbosity. `"full"` (default) always shows action counters: `AM ● a:5 d:1`. `"minimal"` shows `AM ●` alone until the first action is checked or blocked, then shows counters. This reduces startup noise while preserving the diagnostic signal when denials occur.
+`statusStyle` controls the status line verbosity. `"full"` (default) always shows action counters: `AM ● a:5 d:1`. `"minimal"` shows `AM ●` alone until the first action is checked or blocked, then shows counters. `"off"` never shows counters, displaying only `AM ●` or `AM ○`.
 
 Example:
 

--- a/extensions/auto-mode/config.ts
+++ b/extensions/auto-mode/config.ts
@@ -311,6 +311,7 @@ function applyAutoModeScalars(
     ...base,
     enabled: settings.enabled ?? base.enabled,
     classifierModel: settings.classifierModel ?? base.classifierModel,
+    statusStyle: settings.statusStyle ?? base.statusStyle,
     classifierReasoningLevel: isClassifierReasoningLevel(
         settings.classifierReasoningLevel,
       )
@@ -359,6 +360,7 @@ export function buildEffectiveConfigFromSources(
     enabled: true,
     maxUserTranscriptTokens: DEFAULT_MAX_USER_TRANSCRIPT_TOKENS,
     maxToolTranscriptTokens: DEFAULT_MAX_TOOL_TRANSCRIPT_TOKENS,
+    statusStyle: "full",
     environment: [...DEFAULT_ENVIRONMENT],
     allow: [...DEFAULT_ALLOW],
     protectedPaths: [...DEFAULT_PROTECTED_PATHS],

--- a/extensions/auto-mode/state.ts
+++ b/extensions/auto-mode/state.ts
@@ -16,11 +16,15 @@ export function statusLine(
 ): string {
   const enabled = state.enabledOverride ?? config.enabled;
   const circle = enabled ? "●" : "○";
+  const hasActivity = state.checkedActions > 0 || state.blockedActions > 0;
+  if (config.statusStyle === "minimal" && !hasActivity) {
+    return `AM ${circle}`;
+  }
   const allowed = state.checkedActions - state.blockedActions;
   const classifier = state.classifierAllowed > 0 || state.classifierDenied > 0
     ? ` ca:${state.classifierAllowed} cd:${state.classifierDenied}`
     : "";
-  return `AM${circle} a:${allowed} d:${state.blockedActions}${classifier}`;
+  return `AM ${circle} a:${allowed} d:${state.blockedActions}${classifier}`;
 }
 
 export function statusText(

--- a/extensions/auto-mode/state.ts
+++ b/extensions/auto-mode/state.ts
@@ -16,6 +16,9 @@ export function statusLine(
 ): string {
   const enabled = state.enabledOverride ?? config.enabled;
   const circle = enabled ? "●" : "○";
+  if (config.statusStyle === "off") {
+    return `AM ${circle}`;
+  }
   const hasActivity = state.checkedActions > 0 || state.blockedActions > 0;
   if (config.statusStyle === "minimal" && !hasActivity) {
     return `AM ${circle}`;

--- a/extensions/auto-mode/types.ts
+++ b/extensions/auto-mode/types.ts
@@ -36,12 +36,16 @@ export type LogConfig = {
   classifierIo: boolean;
 };
 
+/** Status line verbosity. */
+export type StatusStyle = "full" | "minimal";
+
 export type AutoModeSettings = {
   enabled?: boolean;
   classifierModel?: string;
   classifierReasoningLevel?: ClassifierReasoningLevel;
   maxUserTranscriptTokens?: number;
   maxToolTranscriptTokens?: number;
+  statusStyle?: StatusStyle;
   environment?: unknown;
   allow?: unknown;
   protectedPaths?: unknown;
@@ -78,6 +82,7 @@ export type EffectiveConfig = {
   classifierReasoningLevel?: ClassifierReasoningLevel;
   maxUserTranscriptTokens: number;
   maxToolTranscriptTokens: number;
+  statusStyle: StatusStyle;
   environment: string[];
   allow: string[];
   protectedPaths: string[];

--- a/extensions/auto-mode/types.ts
+++ b/extensions/auto-mode/types.ts
@@ -37,7 +37,7 @@ export type LogConfig = {
 };
 
 /** Status line verbosity. */
-export type StatusStyle = "full" | "minimal";
+export type StatusStyle = "full" | "minimal" | "off";
 
 export type AutoModeSettings = {
   enabled?: boolean;

--- a/tests/auto-mode.test.ts
+++ b/tests/auto-mode.test.ts
@@ -135,6 +135,7 @@ function baseConfig(overrides: Partial<EffectiveConfig> = {}): EffectiveConfig {
 		enabled: true,
 		maxUserTranscriptTokens: 4000,
 		maxToolTranscriptTokens: 4000,
+		statusStyle: "full",
 		environment: [],
 		allow: [],
 		protectedPaths: [...DEFAULT_PROTECTED_PATHS],
@@ -1429,48 +1430,78 @@ test("statusText reports the configured classifier reasoning level", () => {
 test("statusLine: enabled with no classifier calls omits the ca/cd segment", () => {
 	const config = baseConfig();
 	const state = baseState({ checkedActions: 6, blockedActions: 1 });
-	assert.equal(statusLine(config, state), "AM● a:5 d:1");
+	assert.equal(statusLine(config, state), "AM ● a:5 d:1");
 });
 
 test("statusLine: enabled with classifier calls appends ca/cd segment", () => {
 	const config = baseConfig();
 	const state = baseState({ checkedActions: 6, blockedActions: 1, classifierAllowed: 2, classifierDenied: 1 });
-	assert.equal(statusLine(config, state), "AM● a:5 d:1 ca:2 cd:1");
+	assert.equal(statusLine(config, state), "AM ● a:5 d:1 ca:2 cd:1");
 });
 
 test("statusLine: disabled shows empty circle with frozen counts", () => {
 	const config = baseConfig({ enabled: false });
 	const state = baseState({ checkedActions: 18, blockedActions: 3, classifierAllowed: 7, classifierDenied: 5 });
-	assert.equal(statusLine(config, state), "AM○ a:15 d:3 ca:7 cd:5");
+	assert.equal(statusLine(config, state), "AM ○ a:15 d:3 ca:7 cd:5");
 });
 
 test("statusLine: enabledOverride:false overrides an enabled config", () => {
 	const config = baseConfig({ enabled: true });
 	const state = baseState({ enabledOverride: false, checkedActions: 4, blockedActions: 1 });
-	assert.equal(statusLine(config, state), "AM○ a:3 d:1");
+	assert.equal(statusLine(config, state), "AM ○ a:3 d:1");
 });
 
 test("statusLine: allowed is derived from checked minus blocked", () => {
 	const config = baseConfig();
 	const state = baseState({ checkedActions: 10, blockedActions: 3, classifierAllowed: 1, classifierDenied: 1 });
-	assert.equal(statusLine(config, state), "AM● a:7 d:3 ca:1 cd:1");
+	assert.equal(statusLine(config, state), "AM ● a:7 d:3 ca:1 cd:1");
 });
 
 test("statusLine: zero counts render a:0 d:0 with no ca/cd segment", () => {
 	const config = baseConfig();
-	assert.equal(statusLine(config, baseState()), "AM● a:0 d:0");
+	assert.equal(statusLine(config, baseState()), "AM ● a:0 d:0");
 });
 
 test("statusLine: classifier segment shows when only allows have happened", () => {
 	const config = baseConfig();
 	const state = baseState({ checkedActions: 4, blockedActions: 0, classifierAllowed: 3, classifierDenied: 0 });
-	assert.equal(statusLine(config, state), "AM● a:4 d:0 ca:3 cd:0");
+	assert.equal(statusLine(config, state), "AM ● a:4 d:0 ca:3 cd:0");
 });
 
 test("statusLine: classifier segment shows when only denials have happened", () => {
 	const config = baseConfig();
 	const state = baseState({ checkedActions: 2, blockedActions: 2, classifierAllowed: 0, classifierDenied: 2 });
-	assert.equal(statusLine(config, state), "AM● a:0 d:2 ca:0 cd:2");
+	assert.equal(statusLine(config, state), "AM ● a:0 d:2 ca:0 cd:2");
+});
+
+test("statusLine: minimal style hides counters when no activity", () => {
+	const config = baseConfig({ statusStyle: "minimal" });
+	assert.equal(statusLine(config, baseState()), "AM ●");
+});
+
+test("statusLine: minimal style shows counters after first checked action", () => {
+	const config = baseConfig({ statusStyle: "minimal" });
+	const state = baseState({ checkedActions: 3, blockedActions: 1 });
+	assert.equal(statusLine(config, state), "AM ● a:2 d:1");
+});
+
+test("statusLine: minimal style shows counters after first blocked action without checked", () => {
+	const config = baseConfig({ statusStyle: "minimal" });
+	const state = baseState({ checkedActions: 0, blockedActions: 1 });
+	assert.equal(statusLine(config, state), "AM ● a:-1 d:1");
+});
+
+test("statusLine: full style always shows counters even when no activity", () => {
+	const config = baseConfig({ statusStyle: "full" });
+	assert.equal(statusLine(config, baseState()), "AM ● a:0 d:0");
+});
+
+test("statusStyle defaults to full and follows configurable precedence", () => {
+	assert.equal(buildEffectiveConfigFromSources({}).statusStyle, "full");
+	const config = buildEffectiveConfigFromSources({
+		projectLocalSettings: [{ autoMode: { statusStyle: "minimal" as const } }],
+	});
+	assert.equal(config.statusStyle, "minimal");
 });
 
 // --- observability logging -------------------------------------------------

--- a/tests/auto-mode.test.ts
+++ b/tests/auto-mode.test.ts
@@ -1504,6 +1504,12 @@ test("statusStyle defaults to full and follows configurable precedence", () => {
 	assert.equal(config.statusStyle, "minimal");
 });
 
+test("statusLine: off style never shows counters", () => {
+	const config = baseConfig({ statusStyle: "off" });
+	const state = baseState({ checkedActions: 18, blockedActions: 3, classifierAllowed: 7, classifierDenied: 5 });
+	assert.equal(statusLine(config, state), "AM ●");
+});
+
 // --- observability logging -------------------------------------------------
 
 test("log config defaults to disabled with classifier I/O off", () => {


### PR DESCRIPTION
## Summary

Two small improvements to the status line:

1. **Add space after AM indicator** — `AM●` → `AM ●`, consistent with pi-landstrip's `● Sandbox` styling. One-character fix in the template literal.

2. **Add `statusStyle` setting** — `"full"` (default, current behavior) or `"minimal"` (show `AM ●` alone until the first action is checked or blocked, then show counters). Eliminates `a:0 d:0` startup noise while preserving the diagnostic signal when the classifier blocks something (`d:1` prompts you to check `/automode denials`).

## Why

The `a:0 d:0` counters at session start add visual noise with no informational value — nothing has been classified yet. But completely hiding the counters loses the signal when denials happen. The "minimal" style is the middle ground: quiet at start, informative once the classifier is active.

The spacing fix is cosmetic but makes the footer consistent across extensions.

## Changes

- `extensions/auto-mode/state.ts`: add space in template literal; respect `statusStyle` setting
- `extensions/auto-mode/types.ts`: add `StatusStyle` type, `statusStyle` fields in `AutoModeSettings` and `EffectiveConfig`
- `extensions/auto-mode/config.ts`: read `statusStyle` in `buildEffectiveConfigFromSources` and `applyAutoModeScalars`; default `"full"`
- `tests/auto-mode.test.ts`: update existing tests for spacing; add tests for minimal/full styles and config precedence
- `README.md`: document `statusStyle`

## Backward compatibility

Default is `"full"` — existing users see no behavior change except the added space (`AM●` → `AM ●`). The space-only change is cosmetic and unlikely to break anyone parsing the status line (it's a display string, not a machine interface).