### PR TITLE
Make read-only tool classification and fast-stage token budget configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This is project-local and should not be committed. Shared project `.pi/automode.
 
 Set a global default classifier model in `~/.pi/agent/automode.json`; override it per project in `.pi/automode.local.json`.
 
-`classifierReasoningLevel` optionally requests `low`, `medium`, `high`, `xhigh`, or `max` reasoning for both classifier stages. If the key is absent, pi-automode sends no reasoning preference and leaves the choice to the server. Pi AI clamps unsupported values to the nearest level supported by the selected model; a non-reasoning model resolves to `off`. `low` matches Codex Auto Review's reasoning effort and is the practical default when an explicit value is needed. Higher levels can consume the existing 512/1200-token stage limits before producing visible output, which causes the classifier to fail closed.
+`classifierReasoningLevel` optionally requests `low`, `medium`, `high`, `xhigh`, or `max` reasoning for both classifier stages. If the key is absent, pi-automode sends no reasoning preference and leaves the choice to the server. Pi AI clamps unsupported values to the nearest level supported by the selected model; a non-reasoning model resolves to `off`. `low` matches Codex Auto Review's reasoning effort and the practical default when an explicit value is needed. Higher levels can consume the existing 512/1200-token stage limits before producing visible output, which causes the classifier to fail closed. Raise `fastClassifierMaxTokens` (default 512, integer ≥ 16) if you run a reasoning model whose fast-stage budget is truncated before it emits the required `0`/`1` digit.
 
 The setting follows the normal scalar precedence: global, then project-local, then `PI_AUTOMODE_SETTINGS_JSON`. Shared project `.pi/automode.json` cannot set it. Omitting the key at a higher-precedence scope does not clear a lower-precedence value.
 
@@ -96,10 +96,12 @@ Example:
 
 ```json
 {
-  "autoMode": {
-    "classifierModel": "provider/model-id",
-    "classifierReasoningLevel": "low",
-    "maxUserTranscriptTokens": 4000,
+    "autoMode": {
+      "classifierModel": "provider/model-id",
+      "classifierReasoningLevel": "low",
+      "classifyReadOnlyTools": false,
+      "fastClassifierMaxTokens": 512,
+      "maxUserTranscriptTokens": 4000,
     "maxToolTranscriptTokens": 4000,
     "environment": [
       "$defaults",
@@ -169,7 +171,7 @@ The extension blocks these before any allow or classifier decision:
 - root, home, and system-path destructive deletes
 - edits to `.pi/automode*`, `.pi` auto-mode files, and this extension's safety-control files
 
-Read-only Pi tools (`read`, `grep`, `find`, `ls`) are allowed after those checks. Every side-effecting action goes to the classifier, including all `write` and `edit` calls, `bash`, MCP, subagent, network-capable tools, and unknown tools. This keeps classifier hard-deny rules unconditional; direct file writes cannot bypass them.
+Read-only Pi tools (`read`, `grep`, `find`, `ls`) are allowed after those checks. Every side-effecting action goes to the classifier, including all `write` and `edit` calls, `bash`, MCP, subagent, network-capable tools, and unknown tools. This keeps classifier hard-deny rules unconditional; direct file writes cannot bypass them. Set `classifyReadOnlyTools: true` to route read-only tools through the classifier as well, so reads outside the trusted working tree can be denied by policy.
 
 Classification starts with a one-token conservative filter and runs structured review only when that filter requests it. Both stages use a classifier-specific session key and short provider cache retention where the provider supports it. Missing models, provider failures, or malformed responses block the action.
 

--- a/extensions/auto-mode/classifier.ts
+++ b/extensions/auto-mode/classifier.ts
@@ -133,6 +133,8 @@ const FAST_CLASSIFIER_MAX_TOKENS = 512;
 
 export type StagedClassifierOptions = {
   sessionId: string;
+  /** Override the fast-stage token budget; falls back to FAST_CLASSIFIER_MAX_TOKENS. */
+  fastClassifierMaxTokens?: number;
   reasoningLevel?: Exclude<EffectiveClassifierReasoningLevel, "off">;
   onAttempt?: (attempt: ClassifierIoAttempt) => void;
 };
@@ -398,7 +400,8 @@ export async function classifyInStages(
         signal,
         // Reasoning and OpenAI-compatible models may consume hidden reasoning,
         // control, and EOS tokens before emitting the required visible digit.
-        maxTokens: FAST_CLASSIFIER_MAX_TOKENS,
+        maxTokens: options.fastClassifierMaxTokens ??
+          FAST_CLASSIFIER_MAX_TOKENS,
         ...(options.reasoningLevel === undefined
           ? {}
           : { reasoning: options.reasoningLevel }),
@@ -521,6 +524,7 @@ export const defaultClassifyAction: ClassifyAction = async (
     ctx.signal,
     {
       sessionId: classifierCacheSessionId(ctx),
+      fastClassifierMaxTokens: config.fastClassifierMaxTokens,
       reasoningLevel: completionPlan.reasoningLevel,
       onAttempt: (attempt) => attempts.push(attempt),
     },

--- a/extensions/auto-mode/config.ts
+++ b/extensions/auto-mode/config.ts
@@ -2,7 +2,9 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import {
   DEFAULT_ALLOW,
+  DEFAULT_CLASSIFY_READ_ONLY_TOOLS,
   DEFAULT_ENVIRONMENT,
+  DEFAULT_FAST_CLASSIFIER_MAX_TOKENS,
   DEFAULT_HARD_DENY,
   DEFAULT_LOG_CONFIG,
   DEFAULT_MAX_TOOL_TRANSCRIPT_TOKENS,
@@ -99,6 +101,8 @@ export function validateSettingsFile(
         "enabled",
         "classifierModel",
         "classifierReasoningLevel",
+        "classifyReadOnlyTools",
+        "fastClassifierMaxTokens",
         "maxUserTranscriptTokens",
         "maxToolTranscriptTokens",
         "environment",
@@ -134,6 +138,23 @@ export function validateSettingsFile(
       ) {
         diagnostics.push(
           `${source}: autoMode.classifierReasoningLevel must be one of low, medium, high, xhigh, max`,
+        );
+      }
+      if (
+        hasOwn(autoMode, "classifyReadOnlyTools") &&
+        typeof autoMode.classifyReadOnlyTools !== "boolean"
+      ) {
+        diagnostics.push(
+          `${source}: autoMode.classifyReadOnlyTools must be a boolean`,
+        );
+      }
+      if (
+        hasOwn(autoMode, "fastClassifierMaxTokens") &&
+        (!Number.isInteger(autoMode.fastClassifierMaxTokens) ||
+          (autoMode.fastClassifierMaxTokens as number) < 16)
+      ) {
+        diagnostics.push(
+          `${source}: autoMode.fastClassifierMaxTokens must be an integer of at least 16`,
         );
       }
       for (
@@ -302,6 +323,10 @@ function validTranscriptBudget(value: unknown): value is number {
   return Number.isInteger(value) && Number(value) >= 32;
 }
 
+function validFastClassifierBudget(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 16;
+}
+
 function applyAutoModeScalars(
   base: EffectiveConfig,
   settings: AutoModeSettings | undefined,
@@ -316,6 +341,13 @@ function applyAutoModeScalars(
       )
       ? settings.classifierReasoningLevel
       : base.classifierReasoningLevel,
+    classifyReadOnlyTools: settings.classifyReadOnlyTools ??
+      base.classifyReadOnlyTools,
+    fastClassifierMaxTokens: validFastClassifierBudget(
+        settings.fastClassifierMaxTokens,
+      )
+      ? settings.fastClassifierMaxTokens
+      : base.fastClassifierMaxTokens,
     maxUserTranscriptTokens: validTranscriptBudget(
         settings.maxUserTranscriptTokens,
       )
@@ -357,6 +389,8 @@ export function buildEffectiveConfigFromSources(
 ): EffectiveConfig {
   let config: EffectiveConfig = {
     enabled: true,
+    classifyReadOnlyTools: DEFAULT_CLASSIFY_READ_ONLY_TOOLS,
+    fastClassifierMaxTokens: DEFAULT_FAST_CLASSIFIER_MAX_TOKENS,
     maxUserTranscriptTokens: DEFAULT_MAX_USER_TRANSCRIPT_TOKENS,
     maxToolTranscriptTokens: DEFAULT_MAX_TOOL_TRANSCRIPT_TOKENS,
     environment: [...DEFAULT_ENVIRONMENT],

--- a/extensions/auto-mode/constants.ts
+++ b/extensions/auto-mode/constants.ts
@@ -179,6 +179,17 @@ export const PROFILE_FILES = new Set([
 
 export const READ_ONLY_TOOLS = new Set(["read", "grep", "find", "ls"]);
 
+/**
+ * Default behavior: read-only tools bypass the classifier entirely (the
+ * original auto-mode fast path). When set to true via config, read-only tools
+ * are routed through the classifier like any other action, so e.g. reads
+ * outside the trusted working tree can be denied by policy.
+ */
+export const DEFAULT_CLASSIFY_READ_ONLY_TOOLS = false;
+
+/** Default upper bound on fast-stage completion tokens (see PR note). */
+export const DEFAULT_FAST_CLASSIFIER_MAX_TOKENS = 512;
+
 /** Default observability log config: off, classifier I/O off. */
 export const DEFAULT_LOG_CONFIG = {
   enabled: false,

--- a/extensions/auto-mode/extension.ts
+++ b/extensions/auto-mode/extension.ts
@@ -321,7 +321,9 @@ export function createPiAutomode(options: PiAutomodeOptions = {}) {
         }, logCtx);
       }
 
-      if (READ_ONLY_TOOLS.has(event.toolName)) {
+      if (
+        !cfg.classifyReadOnlyTools && READ_ONLY_TOOLS.has(event.toolName)
+      ) {
         return allow(
           ctx,
           "read-only",

--- a/extensions/auto-mode/types.ts
+++ b/extensions/auto-mode/types.ts
@@ -40,6 +40,10 @@ export type AutoModeSettings = {
   enabled?: boolean;
   classifierModel?: string;
   classifierReasoningLevel?: ClassifierReasoningLevel;
+  /** When true, read-only tools (read/grep/find/ls) are classified instead of auto-allowed. */
+  classifyReadOnlyTools?: boolean;
+  /** Override the fast-stage completion token budget (default 512). */
+  fastClassifierMaxTokens?: number;
   maxUserTranscriptTokens?: number;
   maxToolTranscriptTokens?: number;
   environment?: unknown;
@@ -76,6 +80,8 @@ export type EffectiveConfig = {
   enabled: boolean;
   classifierModel?: string;
   classifierReasoningLevel?: ClassifierReasoningLevel;
+  classifyReadOnlyTools: boolean;
+  fastClassifierMaxTokens: number;
   maxUserTranscriptTokens: number;
   maxToolTranscriptTokens: number;
   environment: string[];

--- a/tests/auto-mode.test.ts
+++ b/tests/auto-mode.test.ts
@@ -133,6 +133,8 @@ function createFakeCtx(entries: any[] = [], overrides: Record<string, unknown> =
 function baseConfig(overrides: Partial<EffectiveConfig> = {}): EffectiveConfig {
 	return {
 		enabled: true,
+		classifyReadOnlyTools: false,
+		fastClassifierMaxTokens: 512,
 		maxUserTranscriptTokens: 4000,
 		maxToolTranscriptTokens: 4000,
 		environment: [],
@@ -1044,6 +1046,75 @@ test("tool_call hook allows safe read-only tools without classifier", async () =
 
 	assert.equal(result, undefined);
 	assert.equal(harness.classifierCalls, 0);
+});
+
+test("tool_call routes read-only tools through classifier when classifyReadOnlyTools is true", async () => {
+	const harness = await setupHookTest({
+		config: baseConfig({ classifyReadOnlyTools: true }),
+		classifier: async () => ({ decision: "allow", tier: "allow", reason: "mock allow" }),
+	});
+
+	const result = await harness.emit("tool_call", {
+		toolName: "read",
+		input: { path: "README.md" },
+	}, harness.ctx);
+
+	assert.equal(result, undefined);
+	assert.equal(harness.classifierCalls, 1);
+});
+
+test("tool_call blocks read-only tools via classifier when classifyReadOnlyTools is true and classifier denies", async () => {
+	const harness = await setupHookTest({
+		config: baseConfig({ classifyReadOnlyTools: true }),
+		classifier: async () => ({ decision: "block", tier: "hard_deny", reason: "mock block" }),
+	});
+
+	const result = await harness.emit("tool_call", {
+		toolName: "read",
+		input: { path: "/etc/shadow" },
+	}, harness.ctx) as { block?: boolean; reason?: string };
+
+	assert.equal(result.block, true);
+	assert.match(result.reason ?? "", /mock block/);
+	assert.equal(harness.classifierCalls, 1);
+});
+
+test("classifyReadOnlyTools defaults to false", () => {
+	assert.equal(buildEffectiveConfigFromSources({}).classifyReadOnlyTools, false);
+});
+
+test("fastClassifierMaxTokens defaults to 512 and is configurable", () => {
+	assert.equal(buildEffectiveConfigFromSources({}).fastClassifierMaxTokens, 512);
+	const config = buildEffectiveConfigFromSources({
+		globalSettings: [{ autoMode: { fastClassifierMaxTokens: 2048 } }],
+	});
+	assert.equal(config.fastClassifierMaxTokens, 2048);
+});
+
+test("validateSettingsFile rejects non-boolean classifyReadOnlyTools", () => {
+	const diagnostics = validateSettingsFile(
+		{ autoMode: { classifyReadOnlyTools: "yes" } },
+		"inline",
+	);
+	assert.ok(diagnostics.some((d) => /classifyReadOnlyTools must be a boolean/.test(d)));
+});
+
+test("validateSettingsFile rejects fastClassifierMaxTokens below 16", () => {
+	const diagnostics = validateSettingsFile(
+		{ autoMode: { fastClassifierMaxTokens: 8 } },
+		"inline",
+	);
+	assert.ok(
+		diagnostics.some((d) => /fastClassifierMaxTokens must be an integer of at least 16/.test(d)),
+	);
+});
+
+test("validateSettingsFile accepts valid classifyReadOnlyTools and fastClassifierMaxTokens", () => {
+	const diagnostics = validateSettingsFile(
+		{ autoMode: { classifyReadOnlyTools: true, fastClassifierMaxTokens: 1024 } },
+		"inline",
+	);
+	assert.equal(diagnostics.length, 0);
 });
 
 test("tool_call hook uses classifier mock for non-read-only actions", async () => {


### PR DESCRIPTION
## Summary

Two backward-compatible, opt-in config additions to `autoMode`:

- **`classifyReadOnlyTools`** (default `false`): when `true`, read-only tools (`read`, `grep`, `find`, `ls`) are routed through the classifier instead of the built-in read-only fast path. This lets policy deny reads outside the trusted working tree (e.g. `~/.ssh`, `/etc/shadow`) rather than always auto-allowing them.
- **`fastClassifierMaxTokens`** (default `512`, integer ≥ 16): overrides the hardcoded fast-stage completion budget. Reasoning classifiers can consume the 512-token budget on hidden reasoning before emitting the required `0`/`1` digit, truncating and failing closed; this lets users raise it.

## Why

The read-only fast path is currently unconditional — reads never consult the classifier, so the only way to gate out-of-tree reads is `permissions.deny` patterns, which are coarser than policy. Making it configurable enables a Codex/Claude Code-style auto-review pattern where *every* action (including reads) is subject to the safety classifier.

`fastClassifierMaxTokens` addresses the same class of failure: with a reasoning classifier the fixed `512` budget can truncate the fast stage. It is already a named constant; this just exposes it.

## Behavior

- Default config is unchanged: `classifyReadOnlyTools: false` keeps the read-only bypass; `fastClassifierMaxTokens: 512` is the prior value.
- Both fields are validated in `validateSettingsFile` (boolean / integer ≥ 16) and merged with the existing scalar precedence.

## Test plan

- Added unit tests for config defaults/merge, validation, and the `tool_call` hook routing reads through the classifier when `classifyReadOnlyTools` is `true` (allow and deny paths).
- `npm run check` and `npm test` pass (104 tests).

🤖 Generated with [OpenCode](https://opencode.ai)