### PR TITLE
fix: isolate in-memory observability logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See [Defaults and rule-list behavior](docs/defaults.md) for built-in `environmen
 
 ### Observability logging
 
-Auto mode can write a JSONL observability log next to the current Pi session file, so you can inspect decisions and classifier usage. It is off by default.
+Auto mode can write a JSONL observability log so you can inspect decisions and classifier usage. Persisted sessions use a sidecar next to the Pi session file; in-memory sessions use an application-owned global directory. It is off by default.
 
 ```json
 {
@@ -156,7 +156,7 @@ Auto mode can write a JSONL observability log next to the current Pi session fil
 }
 ```
 
-With logging enabled, the sidecar also writes ccusage-compatible entries for every classifier response. `ccusage pi` reports this usage as a separate `-pi-automode` session even when `classifierIo` is off.
+With logging enabled, persisted-session sidecars also write ccusage-compatible entries for every classifier response. `ccusage pi` reports this usage as a separate `-pi-automode` session even when `classifierIo` is off. In-memory logs use the same entry shape but live outside Pi's normal session tree.
 
 See [Observability logging](docs/observability-logging.md) for the log file location, entry schema, and the `classifierIo` privacy tradeoff. Run `/automode config` to see the resolved log file path.
 

--- a/docs/observability-logging.md
+++ b/docs/observability-logging.md
@@ -1,6 +1,6 @@
 # Observability logging
 
-Auto mode can write a JSONL observability log next to the current Pi session file, so you can inspect decisions and classifier usage. It is off by default and fail-open: a write error never changes an allow/block decision.
+Auto mode can write a JSONL observability log so you can inspect decisions and classifier usage. Persisted sessions use a sidecar next to the Pi session file; in-memory sessions use an application-owned global directory. Logging is off by default and fail-open: a write error never changes an allow/block decision.
 
 ## Enabling
 
@@ -33,9 +33,19 @@ The log file is colocated with the current Pi session file, with `-pi-automode` 
 <session-file>-pi-automode.jsonl     →  <dir>/<id>-pi-automode.jsonl
 ```
 
-For example: `~/.pi/agent/sessions/<slug>/<id>-pi-automode.jsonl`. If no session file is set, it falls back to `<sessionDir>/<sessionId>-pi-automode.jsonl`. Run `/automode config` to see the resolved path.
+For example: `~/.pi/agent/sessions/<slug>/<id>-pi-automode.jsonl`. If a custom session manager provides an absolute, non-empty session directory but no session file, the log falls back to `<sessionDir>/<sessionId>-pi-automode.jsonl`.
 
-There is one combined file per session. Each line is one JSON object with a `type` discriminator. Entries for the same tool call share a `decisionId`.
+Pi in-memory sessions, including `--no-session` and non-persisted subagents, intentionally have neither a session file nor a session directory. Their logs use an absolute application-owned path instead of a relative filename in the launching process directory:
+
+```text
+~/.pi/agent/automode-logs/<encoded-session-cwd>/YYYY-MM-DD/<session-id>-pi-automode.jsonl
+```
+
+The project directory uses the same `--path-with-dashes--` encoding style as Pi's normal session directories, and the date partition is UTC. A custom session manager that supplies an absolute non-empty `sessionDir` without a session file continues to use that directory. Run `/automode config` to see the resolved path for the current session.
+
+Persisted sessions use one combined file per session. In-memory sessions use one file per session ID per UTC day, so a session that crosses midnight continues in the next day's file. Each line is one JSON object with a `type` discriminator. Entries for the same tool call share a `decisionId`.
+
+For persisted sessions, `ccusage pi` continues to report the sidecar as a separate `-pi-automode` session. In-memory logs live outside Pi's normal session tree and may need to be inspected directly.
 
 ## Entry types
 
@@ -82,7 +92,7 @@ One per classifier model response, including malformed responses that trigger a 
 | `message.model` | model ID returned by the classifier provider |
 | `message.usage` | provider-reported input, output, cache, total-token, and cost fields |
 
-`ccusage` reports this sidecar as a separate `-pi-automode` session. This entry contains no prompt or response text, so it is written even when `classifierIo` is off.
+For persisted sessions, `ccusage` reports this sidecar as a separate `-pi-automode` session. This entry contains no prompt or response text, so it is written even when `classifierIo` is off.
 
 ### `classifier`
 

--- a/extensions/auto-mode/extension.ts
+++ b/extensions/auto-mode/extension.ts
@@ -68,6 +68,10 @@ export type PiAutomodeOptions = {
   classifyAction?: ClassifyAction;
   /** Override classifier-model persistence in tests. Runtime code writes ~/.pi/agent/automode.json. */
   saveClassifierModel?: (classifierModel: string) => void;
+  /** Override the application-owned observability log root in tests. */
+  logRoot?: string;
+  /** Override the observability log clock in tests. */
+  now?: () => Date;
 };
 
 type LogCtx = {
@@ -126,6 +130,7 @@ export function createPiAutomode(options: PiAutomodeOptions = {}) {
   const classify = options.classifyAction ?? defaultClassifyAction;
   const saveClassifierModel = options.saveClassifierModel ??
     writeGlobalClassifierModel;
+  const now = options.now ?? (() => new Date());
 
   return function piAutomode(pi: ExtensionAPI) {
     let loadResult = loadConfigWithDiagnostics(process.cwd());
@@ -265,8 +270,11 @@ export function createPiAutomode(options: PiAutomodeOptions = {}) {
           enabled: cfg.log.enabled,
           classifierIo: cfg.log.classifierIo,
           sessionFile: ctx.sessionManager.getSessionFile?.(),
-          sessionDir: ctx.sessionManager.getSessionDir?.() ?? ctx.cwd,
+          sessionDir: ctx.sessionManager.getSessionDir?.() ?? "",
+          sessionCwd: ctx.cwd,
           sessionId: ctx.sessionManager.getSessionId?.() ?? "unknown",
+          logRoot: options.logRoot,
+          now: now(),
         }),
         decisionId: newDecisionId(),
         classifierModel: cfg.classifierModel,
@@ -504,8 +512,11 @@ export function createPiAutomode(options: PiAutomodeOptions = {}) {
       if (command === "config") {
         const logFile = resolveLogPath(
           ctx.sessionManager.getSessionFile?.(),
-          ctx.sessionManager.getSessionDir?.() ?? ctx.cwd,
+          ctx.sessionManager.getSessionDir?.() ?? "",
           ctx.sessionManager.getSessionId?.() ?? "unknown",
+          ctx.cwd,
+          options.logRoot,
+          now(),
         );
         ctx.ui.notify(
           safeJson(

--- a/extensions/auto-mode/log.ts
+++ b/extensions/auto-mode/log.ts
@@ -1,6 +1,7 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
-import { basename, dirname, extname, join } from "node:path";
+import { homedir } from "node:os";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import type {
   ClassifierIo,
   ClassifierIoAttempt,
@@ -65,8 +66,31 @@ export type LoggerOptions = {
   classifierIo: boolean;
   sessionFile?: string;
   sessionDir: string;
+  /** Effective cwd for an in-memory session. */
+  sessionCwd?: string;
   sessionId: string;
+  /** Test/embedder override. Runtime uses ~/.pi/agent/automode-logs. */
+  logRoot?: string;
+  /** Test clock used for the UTC date partition. */
+  now?: Date;
 };
+
+export const DEFAULT_AUTOMODE_LOG_ROOT = join(
+  homedir(),
+  ".pi/agent/automode-logs",
+);
+
+const VALID_SESSION_ID =
+  /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+function safeLogSessionId(sessionId: string): string {
+  if (VALID_SESSION_ID.test(sessionId)) return sessionId;
+  const digest = createHash("sha256")
+    .update(sessionId)
+    .digest("hex")
+    .slice(0, 16);
+  return `invalid-${digest}`;
+}
 
 /** Short id linking a classifier entry to its decision entry in the same file. */
 export function newDecisionId(): string {
@@ -76,19 +100,43 @@ export function newDecisionId(): string {
 /**
  * Derive the log file path from the current session: the session file's
  * directory with `-pi-automode` inserted before the extension. Falls back to
- * `<sessionDir>/<sessionId>-pi-automode.jsonl` when no session file is set.
+ * an absolute session directory when one is available. In-memory sessions use
+ * an application-owned, project- and date-partitioned directory instead of a
+ * relative path resolved against the launching process cwd.
  */
 export function resolveLogPath(
   sessionFile: string | undefined,
   sessionDir: string,
   sessionId: string,
+  sessionCwd = process.cwd(),
+  logRoot = DEFAULT_AUTOMODE_LOG_ROOT,
+  now = new Date(),
 ): string {
   if (sessionFile) {
     const ext = extname(sessionFile);
     const stem = ext ? basename(sessionFile, ext) : basename(sessionFile);
     return join(dirname(sessionFile), `${stem}-pi-automode${ext}`);
   }
-  return join(sessionDir, `${sessionId}-pi-automode.jsonl`);
+
+  const logFile = `${safeLogSessionId(sessionId)}-pi-automode.jsonl`;
+  if (isAbsolute(sessionDir)) {
+    return join(sessionDir, logFile);
+  }
+
+  const resolvedCwd = resolve(sessionCwd);
+  const projectDir = `--${
+    resolvedCwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")
+  }--`;
+  const dateDir = now.toISOString().slice(0, 10);
+  const resolvedLogRoot = isAbsolute(logRoot)
+    ? logRoot
+    : DEFAULT_AUTOMODE_LOG_ROOT;
+  return join(
+    resolvedLogRoot,
+    projectDir,
+    dateDir,
+    logFile,
+  );
 }
 
 /** Append one JSON object as a line. Failures are swallowed: logging must
@@ -105,7 +153,14 @@ function appendJsonl(path: string, entry: unknown): void {
 /** Build a logger bound to one session's log path. No-ops when disabled. */
 export function createLogger(opts: LoggerOptions): Logger {
   const { enabled, classifierIo } = opts;
-  const path = resolveLogPath(opts.sessionFile, opts.sessionDir, opts.sessionId);
+  const path = resolveLogPath(
+    opts.sessionFile,
+    opts.sessionDir,
+    opts.sessionId,
+    opts.sessionCwd,
+    opts.logRoot,
+    opts.now,
+  );
   return {
     enabled,
     classifierIo,

--- a/tests/auto-mode.test.ts
+++ b/tests/auto-mode.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
@@ -74,7 +74,7 @@ function createFakePi() {
 }
 
 function createFakeCtx(entries: any[] = [], overrides: Record<string, unknown> = {}) {
-	const { sessionFile, ...rest } = overrides;
+	const { sessionFile, sessionDir, sessionId, ...rest } = overrides;
 	const notifications: Array<{ message: string; type?: string }> = [];
 	const statuses: Array<{ key: string; text: string | undefined }> = [];
 	const widgets: Array<{ key: string; content: string[] | undefined }> = [];
@@ -98,8 +98,12 @@ function createFakeCtx(entries: any[] = [], overrides: Record<string, unknown> =
 			getBranch: () => entries,
 			buildContextEntries: () => entries,
 			getSessionFile: () => sessionFile as string | undefined,
-			getSessionDir: () => sessionFile ? dirname(sessionFile) : "/tmp",
-			getSessionId: () => "test-session",
+			getSessionDir: () => typeof sessionDir === "string"
+				? sessionDir
+				: sessionFile
+					? dirname(sessionFile as string)
+					: "/tmp",
+			getSessionId: () => typeof sessionId === "string" ? sessionId : "test-session",
 		},
 		ui: {
 			notify(message: string, type?: string) {
@@ -1913,6 +1917,62 @@ test("resolveLogPath falls back to sessionDir/sessionId when no session file", (
 	);
 });
 
+test("resolveLogPath uses the encoded session cwd for in-memory sessions", () => {
+	const logRoot = join(os.tmpdir(), "pi-automode-global-log-root");
+	const sessionCwd = join(os.tmpdir(), "pi-automode-project-marker");
+	const resolvedCwd = resolve(sessionCwd);
+	const projectDir = `--${
+		resolvedCwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")
+	}--`;
+	for (const sessionDir of ["", "relative-session-dir"]) {
+		assert.equal(
+			resolveLogPath(
+				undefined,
+				sessionDir,
+				"abc123",
+				sessionCwd,
+				logRoot,
+				new Date("2026-08-11T12:00:00.000Z"),
+			),
+			join(logRoot, projectDir, "2026-08-11", "abc123-pi-automode.jsonl"),
+		);
+	}
+});
+
+test("resolveLogPath partitions in-memory logs by UTC date", () => {
+	const args = [undefined, "", "abc123", "/tmp/project", "/tmp/logs"] as const;
+	const beforeMidnight = resolveLogPath(
+		...args,
+		new Date("2026-08-11T23:59:59.999Z"),
+	);
+	const afterMidnight = resolveLogPath(
+		...args,
+		new Date("2026-08-12T00:00:00.000Z"),
+	);
+	assert.equal(basename(dirname(beforeMidnight)), "2026-08-11");
+	assert.equal(basename(dirname(afterMidnight)), "2026-08-12");
+	assert.notEqual(beforeMidnight, afterMidnight);
+});
+
+test("resolveLogPath confines invalid custom session ids", () => {
+	const logRoot = resolve(os.tmpdir(), "pi-automode-confined-logs");
+	for (const sessionId of ["../../escape", "..\\..\\escape", ".."]) {
+		const logPath = resolveLogPath(
+			undefined,
+			"",
+			sessionId,
+			"/tmp/project",
+			logRoot,
+			new Date("2026-08-11T12:00:00.000Z"),
+		);
+		assert.equal(relative(logRoot, logPath).startsWith(".."), false);
+		assert.match(
+			basename(logPath),
+			/^invalid-[a-f0-9]{16}-pi-automode\.jsonl$/,
+		);
+	}
+});
+
 test("newDecisionId returns distinct ids", () => {
 	assert.notEqual(newDecisionId(), newDecisionId());
 });
@@ -1924,6 +1984,31 @@ test("createLogger is a no-op when disabled", () => {
 		const logger = createLogger({ enabled: false, classifierIo: true, sessionFile, sessionDir: dir, sessionId: "abc" });
 		logger.append({ type: "decision", ts: "t", decisionId: "d", cwd: "/tmp", tool: "bash", summary: "s", kind: "classifier", outcome: "block", reason: "r", reasoning: { mode: "server-default" } });
 		assert.equal(existsSync(join(dir, "abc-pi-automode.jsonl")), false);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("createLogger writes in-memory logs under the application-owned root", () => {
+	const dir = mkdtempSync(join(os.tmpdir(), "pi-automode-log-"));
+	try {
+		const sessionCwd = join(dir, "project");
+		const logRoot = join(dir, "global-logs");
+		const now = new Date("2026-08-11T12:00:00.000Z");
+		mkdirSync(sessionCwd);
+		const logger = createLogger({
+			enabled: true,
+			classifierIo: false,
+			sessionDir: "",
+			sessionCwd,
+			sessionId: "abc",
+			logRoot,
+			now,
+		});
+		logger.append({ type: "decision", ts: "t", decisionId: "d1", cwd: sessionCwd, tool: "read", summary: "s", kind: "read-only", outcome: "allow", reason: "r", reasoning: { mode: "server-default" } });
+		const logPath = resolveLogPath(undefined, "", "abc", sessionCwd, logRoot, now);
+		assert.equal(existsSync(logPath), true);
+		assert.equal(existsSync(join(sessionCwd, "abc-pi-automode.jsonl")), false);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -2049,6 +2134,62 @@ test("tool_call writes no log file when logging is disabled", async () => {
 		await fake.emit("tool_call", { toolName: "bash", input: { command: "npm publish" } }, ctx);
 		assert.equal(existsSync(join(dir, "sess-pi-automode.jsonl")), false);
 	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("tool_call and config use the in-memory session cwd log path", async () => {
+	const dir = mkdtempSync(join(os.tmpdir(), "pi-automode-hook-log-"));
+	try {
+		const sessionCwd = join(dir, "effective-worktree");
+		const logRoot = join(dir, "automode-logs");
+		const sessionId = `in-memory-${basename(dir)}`;
+		const now = new Date("2026-08-11T12:00:00.000Z");
+		const legacyLaunchPath = join(process.cwd(), `${sessionId}-pi-automode.jsonl`);
+		mkdirSync(sessionCwd);
+		assert.equal(existsSync(legacyLaunchPath), false);
+
+		const fake = createFakePi();
+		createPiAutomode({
+			loadConfig: () => baseConfig({
+				log: { enabled: true, classifierIo: false },
+			}),
+			classifyAction: async () => ({
+				decision: "block",
+				tier: "soft_deny",
+				reason: "unused",
+			}),
+			logRoot,
+			now: () => now,
+		})(fake.pi);
+		const ctx = createFakeCtx(fake.entries, {
+			cwd: sessionCwd,
+			sessionDir: "",
+			sessionId,
+		});
+		await fake.emit("session_start", { type: "session_start" }, ctx);
+		await fake.emit("tool_call", {
+			toolName: "read",
+			input: { path: "README.md" },
+		}, ctx);
+
+		const logPath = resolveLogPath(
+			undefined, "", sessionId, sessionCwd, logRoot, now,
+		);
+		const launchCwdPath = resolveLogPath(
+			undefined, "", sessionId, process.cwd(), logRoot, now,
+		);
+		assert.notEqual(logPath, launchCwdPath);
+		assert.equal(existsSync(logPath), true);
+		assert.equal(existsSync(launchCwdPath), false);
+		assert.equal(existsSync(legacyLaunchPath), false);
+		assert.equal(existsSync(join(sessionCwd, `${sessionId}-pi-automode.jsonl`)), false);
+
+		await fake.commands.get("automode")?.handler("config", ctx);
+		const parsed = JSON.parse(ctx.notifications.at(-1)?.message ?? "{}");
+		assert.equal(parsed.logFile, logPath);
+	} finally {
+		rmSync(join(process.cwd(), `in-memory-${basename(dir)}-pi-automode.jsonl`), { force: true });
 		rmSync(dir, { recursive: true, force: true });
 	}
 });


### PR DESCRIPTION
## Summary

- keep observability logs for persisted Pi sessions beside their session file
- route in-memory/no-session logs to `~/.pi/agent/automode-logs/<encoded-cwd>/YYYY-MM-DD/`
- use the effective session cwd rather than the launching process cwd
- confine invalid custom session IDs to a hashed filename component
- report the same resolved path from `/automode config`
- document UTC date partitioning and persisted-session `ccusage` discovery

## Why

Pi's `SessionManager.inMemory()` intentionally returns no session file and an empty session directory. The previous fallback joined that empty directory with the log filename, producing a relative path that Node resolved against `process.cwd()`. As a result, `--no-session` runs and non-persisted subagents could leave `*-pi-automode.jsonl` files in the parent project, even when the child session ran from another worktree.

Persisted-session sidecar behavior is unchanged. Logging also remains disabled by default.

## Validation

- `npm run check`
- `npm test` (129 tests)
- `npm pack --dry-run`
- `git diff --check`

Tests cover empty and relative session directories, effective-cwd encoding, UTC midnight partitioning, invalid session-ID confinement, the real `tool_call` hook path, and `/automode config` output.

Fixes #12
