### PR TITLE
feat(permissions): add a deterministic permissions.allow tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It reads `autoMode` from Pi-owned config only:
 - `.pi/automode.local.json`
 - `PI_AUTOMODE_SETTINGS_JSON`
 
-It deliberately does not read `autoMode` from shared project `.pi/automode.json`, because a checked-in repo should not be able to weaken auto-mode rules. Shared project config may still contribute `permissions.deny` and `permissions.ask`.
+It deliberately does not read `autoMode` from shared project `.pi/automode.json`, because a checked-in repo should not be able to rewrite the classifier policy, the rule lists, or the classifier model. Shared project config may still contribute `permissions.deny`, `permissions.ask`, and `permissions.allow`, all three treated alike. Note what that means for `permissions.allow`: a checked-in file can declare that certain tool calls skip classifier review, so review a repo's `.pi/automode.json` before trusting it. Deterministic hard-deny checks, `deniedPaths`, and protected-path writes still apply to those calls.
 
 To disable pi-automode for the current project, create or edit `.pi/automode.local.json`:
 
@@ -146,7 +146,8 @@ Example:
   },
   "permissions": {
     "deny": ["bash(rm -rf *)"],
-    "ask": ["bash(git push *)"]
+    "ask": ["bash(git push *)"],
+    "allow": ["bash(git status*)", "example-extension-tool"]
   }
 }
 ```
@@ -184,6 +185,12 @@ See [Observability logging](docs/observability-logging.md) for the log file loca
 
 Permission patterns use Pi tool names, for example `bash(...)`, `write(...)`, `edit(...)`, `read(...)`. The parser accepts capitalized names like `Bash(...)` for convenience, but the documented form is lowercase because Pi tool names are lowercase.
 
+`permissions.allow` (default `[]`) uses the same patterns as a deterministic allow tier, so tools that need no model review — a narrowly scoped command such as `bash(git status*)`, or a side-effect-free tool supplied by another extension or an MCP server — do not cost a classifier call.
+
+Argument scoping is only meaningful for the tools whose primary argument the matcher understands: `bash` (`input.command`), the file tools (the resolved `input.path`), and `grep` (`input.pattern`). For any other tool, including MCP and extension tools, the argument pattern is matched against the serialized input object, so scope those by bare tool name instead — `example-extension-tool` matches every call to that tool. Pi tool names are the ones the providing extension or MCP server exposes; pi-automode does not need to know them in advance.
+
+A match skips the classifier call only. It never skips a deterministic barrier: `permissions.deny`, a declined `permissions.ask`, the deterministic hard-deny checks, and `deniedPaths` are all evaluated first and still block. All three permission lists are read from every permission scope, shared project `.pi/automode.json` included. `write` and `edit` calls whose resolved target is a protected path (`.git/hooks`, `.pi` controls, shell profiles, config files) are never covered by `permissions.allow` and still go to the classifier, the same carve-out the inside-working-directory tier uses.
+
 ## What is enforced before the classifier
 
 The extension blocks these before any allow or classifier decision:
@@ -197,7 +204,7 @@ The extension blocks these before any allow or classifier decision:
 - root, home, and system-path destructive deletes
 - edits to `.pi/automode*`, `.pi` auto-mode files, and this extension's safety-control files
 
-Read-only Pi tools (`read`, `grep`, `find`, `ls`) are allowed after those checks. Every side-effecting action goes to the classifier, including all `write` and `edit` calls, `bash`, MCP, subagent, network-capable tools, and unknown tools. This keeps classifier hard-deny rules unconditional; direct file writes cannot bypass them. Set `classifyReadOnlyTools: true` (default `false`) to route read-only tools through the classifier as well, so reads outside the trusted working tree can be denied by policy. With it enabled, every `read`, `grep`, `find`, and `ls` call runs the two-stage classifier, which raises the number of model calls, the latency, and the cost per session.
+After those checks, `permissions.allow` matches are allowed deterministically — except `write`/`edit` on a protected path, which continues to the classifier. Read-only Pi tools (`read`, `grep`, `find`, `ls`) are allowed next. Every remaining side-effecting action goes to the classifier: `write` and `edit` calls, `bash`, MCP, subagent, network-capable tools, and unknown tools. With the default empty `permissions.allow`, that covers every write and edit the deterministic checks above did not already block. This keeps classifier hard-deny rules unconditional; direct file writes cannot bypass them unless you opt in with a `permissions.allow` pattern, which still cannot cover protected-path writes and edits. Set `classifyReadOnlyTools: true` (default `false`) to route read-only tools through the classifier as well, so reads outside the trusted working tree can be denied by policy. With it enabled, every `read`, `grep`, `find`, and `ls` call runs the two-stage classifier, which raises the number of model calls, the latency, and the cost per session.
 
 Path matches in `deniedPaths` are blocked before every classifier and fast-path decision, so secret and system paths never reach the model through the file tools. The deny list does not govern `bash`; shell access to those paths is handled by the classifier and the deterministic hard-deny checks. With `allowInsideWorkingDirectory: true`, file tools inside the working directory are allowed without a classifier call, and outside-working-directory file access (reads included) goes to the classifier.
 
@@ -219,7 +226,7 @@ npm test
 npm pack --dry-run
 ```
 
-The tests cover the risky parts: scoped permission matching, config-source precedence, `$defaults` behavior, config diagnostics, deterministic hard-deny checks, shell parsing, write/edit classifier routing, symlink-aware safety-control checks, token-budgeted transcript selection, staged classifier parsing and caching options, and hook-level blocking/allowing.
+The tests cover the risky parts: scoped permission matching, the deterministic `permissions.allow` tier and its ordering guarantees, config-source precedence, `$defaults` behavior, config diagnostics, deterministic hard-deny checks, shell parsing, write/edit classifier routing, symlink-aware safety-control checks, token-budgeted transcript selection, staged classifier parsing and caching options, and hook-level blocking/allowing.
 
 ## Publishing
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -10,6 +10,8 @@ The ordered pipeline that runs on every agent tool call before execution. See [A
 
 **Deterministic hard-deny** — Local code checks that block high-risk actions before any classifier call and cannot be overridden. Distinct from the config-level [hard_deny](#classifier-policy-and-rules); independent of the model.
 
+**`permissions.allow` tier** — Opt-in list of scoped tool patterns whose matches skip the classifier call after every deterministic check has passed. It cannot override a deny, and it excludes `write`/`edit` on protected paths. Distinct from the prose [autoMode.allow](#classifier-policy-and-rules) exceptions.
+
 **Read-only bypass** — The default fast path where the read-only tools (`read`, `grep`, `find`, `ls`) are allowed without classifier review once permission and deterministic checks pass. `classifyReadOnlyTools` routes them through the classifier instead.
 
 **Staged classifier** — The two-stage safety classifier: a conservative one-token filter gates an optional structured review. See [Fast stage](#enforcement-flow) and [Detailed stage](#enforcement-flow).
@@ -27,6 +29,8 @@ The classifier's deny tiers and rule-list syntax. See [Defaults and rule-list be
 **soft_deny** — Overridable classifier block rules, unlike [hard_deny](#classifier-policy-and-rules).
 
 **explicit_intent** — A classifier tier meaning the allow was justified because the user's latest instruction directly and specifically authorized an otherwise [soft-denied](#classifier-policy-and-rules) action.
+
+**allow exception** (`autoMode.allow`) — Prose rules that let the classifier allow an action a [soft_deny](#classifier-policy-and-rules) rule would otherwise block. They never override [hard_deny](#classifier-policy-and-rules) and are unrelated to the [`permissions.allow` tier](#enforcement-flow).
 
 **`$defaults`** — A section-local marker in a rule list that expands to the built-in entries for that list.
 

--- a/docs/automode-classifier-flow.md
+++ b/docs/automode-classifier-flow.md
@@ -14,10 +14,11 @@ For each Pi `tool_call` event, the extension does this:
 6. Run deterministic hard-deny checks.
 7. Let the extension-owned `automode_inspect` tool run without classification, counters, state persistence, or logging.
 8. Run the path gate: `deniedPaths` matches block locally; with `allowInsideWorkingDirectory`, in-tree non-protected file access is allowed without a classifier call.
-9. Allow read-only built-in tools without a classifier call, unless `classifyReadOnlyTools` routes them through the classifier.
-10. Send every remaining action, including all writes and edits, through a one-token conservative filter.
-11. Run structured classifier review only when the filter requests it, then allow or block.
-12. Persist state and update the UI status/denial history.
+9. Allow `permissions.allow` matches without a classifier call, except `write`/`edit` on a protected path.
+10. Allow read-only built-in tools without a classifier call, unless `classifyReadOnlyTools` routes them through the classifier.
+11. Send every action no earlier tier allowed or blocked through a one-token conservative filter. With the default empty `permissions.allow`, that includes every write and edit that reaches this step.
+12. Run structured classifier review only when the filter requests it, then allow or block.
+13. Persist state and update the UI status/denial history.
 
 The default posture is fail-closed. If the classifier cannot be resolved, has no API key, errors, or returns an invalid stage response, the action is blocked.
 
@@ -49,7 +50,10 @@ flowchart TD
 
   K2 -- denied --> K1[Block locally]
   K2 -- in-tree, non-protected --> L1[Allow locally]
-  K2 -- no match or tier off --> L{Read-only built-in tool?}
+  K2 -- no match or tier off --> K3{Matches permissions.allow?}
+
+  K3 -- yes, not a protected write/edit --> L1[Allow locally]
+  K3 -- no match, or protected write/edit --> L{Read-only built-in tool?}
 
   L -- yes --> L1[Allow locally]
   L -- no --> N[Run one-token filter]
@@ -82,9 +86,13 @@ The effective config combines these sources:
 - `~/.pi/agent/automode.json`
 - `.pi/automode.local.json`
 - `PI_AUTOMODE_SETTINGS_JSON`
-- shared `.pi/automode.json`, but only for `permissions.deny` and `permissions.ask`
+- shared `.pi/automode.json`, but only for `permissions.deny`, `permissions.ask`, and `permissions.allow`
 
-Shared project `.pi/automode.json` cannot change `autoMode` rules. That is deliberate: a checked-in repo must not be able to weaken auto-mode. It may still add Pi permission rules.
+Shared project `.pi/automode.json` cannot change `autoMode` rules. That is deliberate: a checked-in repo must not be able to rewrite the classifier policy, the rule lists, or the classifier model. It may still add Pi permission rules.
+
+All three permission lists (`deny`, `ask`, `allow`) come from all four scopes, with no special casing for `permissions.allow`. Permission patterns are appended in the order global, shared project, project-local, inline; the order only affects which rule is reported when several match, since `deny` and `ask` are evaluated before `allow` regardless of scope.
+
+`permissions.allow` is the one way a shared config can narrow classifier coverage: a checked-in list can declare that certain tool calls skip classifier review. The deterministic tiers — hard-deny checks, `deniedPaths`, and protected-path writes and edits — still apply to those calls, so read a repo's `.pi/automode.json` before trusting it.
 
 To disable pi-automode for the current project, set `autoMode.enabled` to `false` in `.pi/automode.local.json`:
 
@@ -135,6 +143,22 @@ If a rule matches and no UI is available, the action is blocked. If UI is availa
 
 Approving that dialog does not run the tool directly. It only lets the action continue to the normal auto-mode checks, including deterministic hard-deny checks and classifier review.
 
+### `permissions.allow`
+
+`permissions.allow` is a deterministic allow tier. It uses the same patterns as `deny`/`ask`, so it covers built-in, MCP, and extension tools:
+
+```json
+"permissions": { "allow": ["bash(git status*)", "example-extension-tool"] }
+```
+
+Argument scoping works for the tools whose primary argument the matcher understands (`bash`, the file tools, `grep`). MCP and extension tools have no known primary argument, so match them by bare tool name; an argument pattern would be compared against their serialized input object.
+
+A match skips the classifier call and nothing else. The tier runs after `permissions.deny`, `permissions.ask`, the deterministic hard-deny checks, and the path gate, so it cannot turn a deterministic block into an allow. One further limit: `write` and `edit` calls whose resolved target is a protected path are excluded and still reach the classifier, mirroring the `allowInsideWorkingDirectory` carve-out.
+
+Entries come from every permission scope, shared project `.pi/automode.json` included (see [Config loading](#config-loading)).
+
+The default is an empty list, so nothing changes without an explicit opt-in. Decision log entries for this tier use `kind: permissions.allow`; `/automode status` reports the rule count and `/automode config` shows the resolved patterns.
+
 ### Deterministic hard-deny checks
 
 Some actions are too risky to leave to the classifier. These are blocked locally, before any classifier call.
@@ -155,7 +179,7 @@ Recursive-delete checks treat `/`, the user's home root, and top-level system ro
 
 ### Read-only bypass and the path gate
 
-Read-only built-in tools are allowed without classifier review after the checks above pass, unless `classifyReadOnlyTools: true` routes them through the classifier instead.
+Read-only built-in tools are allowed without classifier review after the checks above and the `permissions.allow` tier pass, unless `classifyReadOnlyTools: true` routes them through the classifier instead.
 
 The read-only tool set is:
 
@@ -165,11 +189,11 @@ read, grep, find, ls
 
 Reads to protected paths are still allowed.
 
-Two opt-in settings change the deterministic tier. `deniedPaths` blocks matching file-tool paths locally, before the classifier and any fast path. `allowInsideWorkingDirectory: true` allows file access inside the working directory without a classifier call — writes and edits included — while out-of-tree file access is routed to the classifier (reads included). Writes and edits to protected in-tree paths are exempt from the silent-allow tier and still reach the classifier. In the default configuration (both settings off), every write and edit is classifier-reviewed, whether or not its target is protected.
+Two opt-in settings change the deterministic tier. `deniedPaths` blocks matching file-tool paths locally, before the classifier and any fast path. `allowInsideWorkingDirectory: true` allows file access inside the working directory without a classifier call — writes and edits included — while out-of-tree file access is routed to the classifier (reads included). Writes and edits to protected in-tree paths are exempt from the silent-allow tier and still reach the classifier. In the default configuration (both settings off and `permissions.allow` empty), every write and edit is classifier-reviewed, whether or not its target is protected.
 
 ## Protected paths
 
-The protected-path configuration identifies safety-sensitive targets such as `.git`, `.pi`, editor config directories, shell profiles, package-manager config files, hook configs, and similar files. In the default configuration every write and edit goes to the classifier, so there is no direct-write allow path that can bypass classifier policy. With `allowInsideWorkingDirectory: true`, non-protected in-tree writes take the deterministic allow tier, but protected targets still route to the classifier. `deniedPaths` can hard-deny any of these targets before the classifier.
+The protected-path configuration identifies safety-sensitive targets such as `.git`, `.pi`, editor config directories, shell profiles, package-manager config files, hook configs, and similar files. In the default configuration every write and edit goes to the classifier, so there is no direct-write allow path that can bypass classifier policy. Two opt-ins add such a path for non-protected targets, and both keep protected targets on the classifier route: with `allowInsideWorkingDirectory: true`, non-protected in-tree writes take the deterministic allow tier, and a matching `permissions.allow` pattern behaves the same way. `deniedPaths` can hard-deny any of these targets before the classifier.
 
 Deterministic safety-control checks still resolve paths canonically before classification. This catches writes through symlinks to auto-mode controls, shell profiles, and SSH authorization files without relying on the model.
 

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -136,5 +136,7 @@ If you omit `$defaults`, you replace the built-ins for that section:
 
 That means: use only that one `allow` entry. The built-in `allow` entries are not used. Replacing `allow` does not replace `soft_deny`, `hard_deny`, `protectedPaths`, or `environment`.
 
-`$defaults` is not used in `permissions.deny` or `permissions.ask`. Those lists contain only explicit Pi tool patterns.
+`$defaults` is not used in `permissions.deny`, `permissions.ask`, or `permissions.allow`. Those lists contain only explicit Pi tool patterns, and all three default to empty.
+
+Note that `autoMode.allow` and `permissions.allow` are different things: `autoMode.allow` holds prose allow exceptions that the classifier weighs against soft-deny rules, while `permissions.allow` holds tool patterns that skip the classifier call entirely.
 

--- a/docs/observability-logging.md
+++ b/docs/observability-logging.md
@@ -61,7 +61,7 @@ One per tool-call decision. Every allow and every block goes through exactly one
 | `cwd` | working directory |
 | `tool` | tool name, e.g. `bash`, `write` |
 | `summary` | `actionSummary` — tool name + input JSON (truncated) |
-| `kind` | enforcement path: `permissions.deny`, `permissions.ask`, `deterministic-hard-deny`, `classifier`, or `read-only` |
+| `kind` | enforcement path: `permissions.deny`, `permissions.ask`, `deterministic-hard-deny`, `permissions.allow`, `classifier`, or `read-only` |
 | `outcome` | `allow` or `block` |
 | `reason` | the reason string (classifier reason, or the deterministic/permission reason) |
 | `classifierModel` | the configured classifier model, when relevant |
@@ -79,7 +79,7 @@ or an explicit request after model-level clamping:
 {"mode":"explicit","requestedLevel":"max","effectiveLevel":"xhigh"}
 ```
 
-Classifier-routed decisions contain the effective level once the configured model resolves, even when `classifierIo` is off or authentication then fails. If the configured model itself cannot be resolved, an explicit entry records `requestedLevel` without `effectiveLevel` because no model-supported level exists. A local permission, deterministic, or read-only decision does not run the classifier and likewise may omit `effectiveLevel`. In `server-default` mode, the concrete server-selected level is not observable and is not inferred.
+Classifier-routed decisions contain the effective level once the configured model resolves, even when `classifierIo` is off or authentication then fails. If the configured model itself cannot be resolved, an explicit entry records `requestedLevel` without `effectiveLevel` because no model-supported level exists. A local permission, deterministic, `permissions.allow`, or read-only decision does not run the classifier and likewise may omit `effectiveLevel`. In `server-default` mode, the concrete server-selected level is not observable and is not inferred.
 
 ### `message` (classifier usage)
 

--- a/examples/automode.local.json
+++ b/examples/automode.local.json
@@ -28,6 +28,10 @@
     ]
   },
   "permissions": {
+    "allow": [
+      "bash(git status*)",
+      "example-extension-tool"
+    ],
     "ask": [
       "bash(git push *)"
     ],

--- a/extensions/auto-mode/config.ts
+++ b/extensions/auto-mode/config.ts
@@ -246,11 +246,11 @@ export function validateSettingsFile(
     } else {
       const permissions = settings.permissions as Record<string, unknown>;
       for (const key of Object.keys(permissions)) {
-        if (key !== "deny" && key !== "ask") {
+        if (key !== "deny" && key !== "ask" && key !== "allow") {
           diagnostics.push(`${source}: unknown permissions key ${key}`);
         }
       }
-      for (const key of ["deny", "ask"] as const) {
+      for (const key of ["deny", "ask", "allow"] as const) {
         const value = permissions[key];
         if (value === undefined) continue;
         if (!Array.isArray(value)) {
@@ -444,7 +444,7 @@ function applyAutoModeScalars(
 function appendPermissionPatterns(
   target: ToolPattern[],
   settings: SettingsFile | undefined,
-  key: "deny" | "ask",
+  key: "deny" | "ask" | "allow",
 ): void {
   const values = stringArray(settings?.permissions?.[key]);
   if (!values) return;
@@ -459,7 +459,10 @@ function appendPermissionPatterns(
  *
  * Important details:
  * - shared project `.pi/automode.json` contributes `permissions.*` but not `autoMode`,
- *   so a checked-in repo cannot weaken classifier rules;
+ *   so a checked-in repo cannot rewrite the classifier policy or rule lists; note
+ *   that its `permissions.allow` entries can still narrow classifier coverage,
+ *   because a matching pattern skips the classifier call (the deterministic tiers
+ *   still apply);
  * - global, project-local, and inline `autoMode` settings combine additively across scopes;
  * - omitting `$defaults` in any scope for a rule list means "replace built-ins" for that list.
  */
@@ -482,6 +485,7 @@ export function buildEffectiveConfigFromSources(
     hardDeny: [...DEFAULT_HARD_DENY],
     permissionDeny: [],
     permissionAsk: [],
+    permissionAllow: [],
     log: { ...DEFAULT_LOG_CONFIG },
   };
 
@@ -538,6 +542,7 @@ export function buildEffectiveConfigFromSources(
   ) {
     appendPermissionPatterns(config.permissionDeny, settings, "deny");
     appendPermissionPatterns(config.permissionAsk, settings, "ask");
+    appendPermissionPatterns(config.permissionAllow, settings, "allow");
   }
 
   return config;

--- a/extensions/auto-mode/extension.ts
+++ b/extensions/auto-mode/extension.ts
@@ -367,8 +367,12 @@ export function createPiAutomode(options: PiAutomodeOptions = {}) {
       // Enforcement order:
       // 1. permission deny/ask rules,
       // 2. deterministic hard-deny checks that never consult the model,
-      // 3. read-only built-in fast path (skipped when classifyReadOnlyTools is set),
-      // 4. classifier for every remaining action, fail-closed on setup/parse errors.
+      // 3. extension-owned read-only inspection tool,
+      // 4. deterministic path gate (deniedPaths, then the inside-CWD tier),
+      // 5. permissions.allow tier: skips the classifier only, never a
+      //    deterministic barrier, and never a protected-path write/edit,
+      // 6. read-only built-in fast path (skipped when classifyReadOnlyTools is set),
+      // 7. classifier for every remaining action, fail-closed on setup/parse errors.
       const cfg = effectiveConfig();
       if (!cfg.enabled) return undefined;
       if (ctx.signal?.aborted) return { block: true, reason: "Cancelled" };
@@ -521,6 +525,40 @@ export function createPiAutomode(options: PiAutomodeOptions = {}) {
             readOnlyFastPath = false;
           }
         }
+      }
+
+      // Deterministic allow tier. It runs after every deterministic denial
+      // (permissions.deny, permissions.ask, hard-deny checks, deniedPaths), so
+      // an allow pattern can only skip the classifier call, never a barrier.
+      for (const pattern of cfg.permissionAllow) {
+        if (!matchesToolPattern(pattern, event.toolName, input, ctx.cwd)) {
+          continue;
+        }
+        // A protected-path write/edit is never covered by permissions.allow; it
+        // stays on the classifier path (same rule as the inside-CWD tier).
+        if (event.toolName === "write" || event.toolName === "edit") {
+          const inputPath = extractInputPath(event.toolName, input);
+          const expanded = inputPath === undefined
+            ? undefined
+            : expandHomePattern(inputPath);
+          const resolved = expanded === undefined
+            ? undefined
+            : resolveInputPath(ctx.cwd, expanded) ?? expanded;
+          if (
+            resolved !== undefined &&
+            isProtectedPath(resolved, ctx.cwd, cfg.protectedPaths)
+          ) {
+            break;
+          }
+        }
+        return allow(
+          ctx,
+          "permissions.allow",
+          `Allowed by permissions.allow: ${pattern.raw}`,
+          event.toolName,
+          summary,
+          logCtx,
+        );
       }
 
       if (readOnlyFastPath) {

--- a/extensions/auto-mode/state.ts
+++ b/extensions/auto-mode/state.ts
@@ -37,6 +37,7 @@ export function statusText(
     `classifier denied: ${state.classifierDenied}`,
     `permissions.deny rules: ${config.permissionDeny.length}`,
     `permissions.ask rules: ${config.permissionAsk.length}`,
+    `permissions.allow rules: ${config.permissionAllow.length}`,
     `environment entries: ${config.environment.length}`,
     `allow entries: ${config.allow.length}`,
     `soft_deny entries: ${config.softDeny.length}`,

--- a/extensions/auto-mode/types.ts
+++ b/extensions/auto-mode/types.ts
@@ -67,6 +67,11 @@ export type SettingsFile = {
   permissions?: {
     deny?: unknown;
     ask?: unknown;
+    /**
+     * Deterministic allow tier: matching calls skip the classifier only. Read
+     * from every permission scope, exactly like `deny` and `ask`.
+     */
+    allow?: unknown;
   };
 };
 
@@ -100,6 +105,7 @@ export type EffectiveConfig = {
   hardDeny: string[];
   permissionDeny: ToolPattern[];
   permissionAsk: ToolPattern[];
+  permissionAllow: ToolPattern[];
   log: LogConfig;
 };
 
@@ -131,6 +137,7 @@ export type DenialRecord = {
 /** Denial kind plus the deterministic allow fast paths, used for decision log entries. */
 export type DecisionKind =
   | DenialRecord["kind"]
+  | "permissions.allow"
   | "read-only"
   | "inside-working-directory";
 

--- a/tests/auto-mode.test.ts
+++ b/tests/auto-mode.test.ts
@@ -23,6 +23,7 @@ import {
 	createPiAutomode,
 	deterministicHardDeny,
 	isRootHomeOrSystemPath,
+	loadEffectiveConfigWithDiagnostics,
 	matchesProtectedPath,
 	matchesToolPattern,
 	modelVisibleConfigDiagnostics,
@@ -188,6 +189,7 @@ function baseConfig(overrides: Partial<EffectiveConfig> = {}): EffectiveConfig {
 		hardDeny: [],
 		permissionDeny: [],
 		permissionAsk: [],
+		permissionAllow: [],
 		log: { ...DEFAULT_LOG_CONFIG },
 		...overrides,
 	};
@@ -471,6 +473,7 @@ test("project shared Pi settings can add permissions but cannot weaken autoMode"
 				},
 				permissions: {
 					deny: ["bash(git push --force*)"],
+					allow: ["bash(*)"],
 				},
 			},
 		],
@@ -481,6 +484,73 @@ test("project shared Pi settings can add permissions but cannot weaken autoMode"
 	assert.equal(config.hardDeny.includes("checked-in repo tries to replace hard denies"), false);
 	assert.equal(config.permissionDeny.length, 1);
 	assert.equal(config.permissionDeny[0]?.raw, "bash(git push --force*)");
+	assert.deepEqual(config.permissionAllow.map((pattern) => pattern.raw), ["bash(*)"]);
+});
+
+test("permissions.allow is read from every permission scope, like deny and ask", () => {
+	assert.deepEqual(buildEffectiveConfigFromSources({}).permissionAllow, []);
+
+	const config = buildEffectiveConfigFromSources({
+		globalSettings: [{ permissions: { allow: ["noop"] } }],
+		projectSharedSettings: [{ permissions: { allow: ["bash(*)"], deny: ["bash(rm -rf *)"] } }],
+		projectLocalSettings: [{ permissions: { allow: ["bash(git status*)"] } }],
+		inlineSettings: [{ permissions: { allow: ["example-extension-tool"] } }],
+	});
+
+	assert.deepEqual(config.permissionAllow.map((pattern) => pattern.raw), [
+		"noop",
+		"bash(*)",
+		"bash(git status*)",
+		"example-extension-tool",
+	]);
+	assert.deepEqual(config.permissionDeny.map((pattern) => pattern.raw), ["bash(rm -rf *)"]);
+});
+
+test("shared project permissions.allow is loaded from disk without diagnostics", () => {
+	const project = mkdtempSync(join(os.tmpdir(), "pi-automode-shared-allow-"));
+	try {
+		mkdirSync(join(project, ".pi"), { recursive: true });
+		writeFileSync(
+			join(project, ".pi/automode.json"),
+			JSON.stringify({ permissions: { allow: ["bash(git status*)"], deny: ["bash(rm -rf *)"] } }),
+		);
+
+		const { config, diagnostics } = loadEffectiveConfigWithDiagnostics(project);
+
+		assert.equal(
+			config.permissionAllow.some((pattern) => pattern.raw === "bash(git status*)"),
+			true,
+		);
+		assert.equal(config.permissionDeny.some((pattern) => pattern.raw === "bash(rm -rf *)"), true);
+		assert.equal(diagnostics.some((line) => line.includes(join(project, ".pi/automode.json"))), false);
+	} finally {
+		rmSync(project, { recursive: true, force: true });
+	}
+});
+
+test("validateSettingsFile accepts permissions.allow and validates its entries", () => {
+	assert.deepEqual(
+		validateSettingsFile({ permissions: { allow: ["noop", "bash(git status*)"] } }, "inline"),
+		[],
+	);
+
+	const notAnArray = validateSettingsFile(
+		{ permissions: { allow: "noop" } },
+		"inline",
+	);
+	assert.deepEqual(notAnArray, ["inline: permissions.allow must be an array of tool patterns"]);
+
+	const badEntry = validateSettingsFile(
+		{ permissions: { allow: ["noop", 42] } },
+		"inline",
+	);
+	assert.deepEqual(badEntry, ["inline: permissions.allow[1] must be a tool pattern string"]);
+
+	assert.equal(
+		validateSettingsFile({ permissions: { allow: ["noop"] } }, "inline")
+			.some((line) => line.includes("unknown permissions key")),
+		false,
+	);
 });
 
 test("project-local classifier model overrides global classifier model", () => {
@@ -1441,6 +1511,183 @@ test("tool_call blocks read-only tools via classifier when classifyReadOnlyTools
 	assert.equal(result.block, true);
 	assert.match(result.reason ?? "", /mock block/);
 	assert.equal(harness.classifierCalls, 1);
+});
+
+test("tool patterns for MCP and extension tools match by bare tool name only", () => {
+	const bare = parseToolPattern("example-extension-tool");
+	assert.ok(bare);
+	assert.equal(
+		matchesToolPattern(bare, "example-extension-tool", { query: "docs" }, process.cwd()),
+		true,
+	);
+
+	// Tools with no known primary argument fall back to the serialized input, so
+	// an argument-scoped pattern such as `mcp(example-server*)` never matches.
+	// Documentation must therefore recommend bare tool names for those tools.
+	const scoped = parseToolPattern("mcp(example-server*)");
+	assert.ok(scoped);
+	assert.equal(
+		matchesToolPattern(scoped, "mcp", { tool: "example-server_search" }, process.cwd()),
+		false,
+	);
+});
+
+test("permissions.allow skips the classifier for a non-built-in tool", async () => {
+	const pattern = parseToolPattern("noop");
+	assert.ok(pattern);
+	const harness = await setupHookTest({
+		config: baseConfig({ permissionAllow: [pattern] }),
+	});
+
+	const result = await harness.emit("tool_call", {
+		toolName: "noop",
+		input: {},
+	}, harness.ctx);
+
+	assert.equal(result, undefined);
+	assert.equal(harness.classifierCalls, 0);
+});
+
+test("permissions.allow keeps argument scope and lets non-matching calls reach the classifier", async () => {
+	const pattern = parseToolPattern("bash(git status*)");
+	assert.ok(pattern);
+	const harness = await setupHookTest({
+		config: baseConfig({ permissionAllow: [pattern] }),
+	});
+
+	const allowed = await harness.emit("tool_call", {
+		toolName: "bash",
+		input: { command: "git status --short" },
+	}, harness.ctx);
+	assert.equal(allowed, undefined);
+	assert.equal(harness.classifierCalls, 0);
+
+	const classified = await harness.emit("tool_call", {
+		toolName: "bash",
+		input: { command: "git push" },
+	}, harness.ctx);
+	assert.equal(classified, undefined);
+	assert.equal(harness.classifierCalls, 1);
+});
+
+test("permissions.deny wins over permissions.allow", async () => {
+	const deny = parseToolPattern("bash(git push --force*)");
+	const allow = parseToolPattern("bash(*)");
+	assert.ok(deny);
+	assert.ok(allow);
+	const harness = await setupHookTest({
+		config: baseConfig({ permissionDeny: [deny], permissionAllow: [allow] }),
+	});
+
+	const result = await harness.emit("tool_call", {
+		toolName: "bash",
+		input: { command: "git push --force origin main" },
+	}, harness.ctx) as { block?: boolean; reason?: string };
+
+	assert.equal(result.block, true);
+	assert.match(result.reason ?? "", /permissions\.deny/);
+	assert.equal(harness.classifierCalls, 0);
+});
+
+test("deterministic hard-deny wins over permissions.allow", async () => {
+	const pattern = parseToolPattern("write(*)");
+	assert.ok(pattern);
+	const harness = await setupHookTest({
+		config: baseConfig({ permissionAllow: [pattern] }),
+	});
+
+	const result = await harness.emit("tool_call", {
+		toolName: "write",
+		input: { path: ".pi/automode.local.json", content: "{}" },
+	}, harness.ctx) as { block?: boolean; reason?: string };
+
+	assert.equal(result.block, true);
+	assert.match(result.reason ?? "", /safety-control/);
+	assert.equal(harness.classifierCalls, 0);
+});
+
+test("deniedPaths wins over permissions.allow", async () => {
+	const pattern = parseToolPattern("read(*)");
+	assert.ok(pattern);
+	const harness = await setupHookTest({
+		config: baseConfig({
+			deniedPaths: ["*/secrets.env"],
+			permissionAllow: [pattern],
+		}),
+	});
+
+	const result = await harness.emit("tool_call", {
+		toolName: "read",
+		input: { path: "secrets.env" },
+	}, harness.ctx) as { block?: boolean; reason?: string };
+
+	assert.equal(result.block, true);
+	assert.match(result.reason ?? "", /Path denied by policy/);
+	assert.equal(harness.classifierCalls, 0);
+});
+
+test("permissions.allow does not cover protected in-tree writes", async () => {
+	const pattern = parseToolPattern("write(*)");
+	assert.ok(pattern);
+	const project = mkdtempSync(join(os.tmpdir(), "pi-automode-allow-protected-"));
+	try {
+		const harness = await setupHookTest({
+			config: baseConfig({ permissionAllow: [pattern] }),
+			ctx: createFakeCtx([], { cwd: project }),
+			classifier: async () => ({ decision: "block", tier: "soft_deny", reason: "protected hook write" }),
+		});
+
+		const blocked = await harness.emit("tool_call", {
+			toolName: "write",
+			input: { path: ".git/hooks/pre-commit", content: "#!/bin/sh\n" },
+		}, harness.ctx) as { block?: boolean; reason?: string };
+		assert.equal(blocked.block, true);
+		assert.match(blocked.reason ?? "", /protected hook write/);
+		assert.equal(harness.classifierCalls, 1);
+
+		const allowed = await harness.emit("tool_call", {
+			toolName: "write",
+			input: { path: "src/app.ts", content: "export const x = 1;\n" },
+		}, harness.ctx);
+		assert.equal(allowed, undefined);
+		assert.equal(harness.classifierCalls, 1);
+	} finally {
+		rmSync(project, { recursive: true, force: true });
+	}
+});
+
+test("permissions.allow does not cover protected out-of-tree edits", async () => {
+	const pattern = parseToolPattern("edit(*)");
+	assert.ok(pattern);
+	const base = mkdtempSync(join(os.tmpdir(), "pi-automode-allow-outside-"));
+	try {
+		const project = join(base, "project");
+		mkdirSync(join(base, "other/.git"), { recursive: true });
+		mkdirSync(project, { recursive: true });
+		const harness = await setupHookTest({
+			config: baseConfig({ permissionAllow: [pattern] }),
+			ctx: createFakeCtx([], { cwd: project }),
+			classifier: async () => ({ decision: "block", tier: "soft_deny", reason: "foreign git config" }),
+		});
+
+		const blocked = await harness.emit("tool_call", {
+			toolName: "edit",
+			input: { path: "../other/.git/config", oldText: "a", newText: "b" },
+		}, harness.ctx) as { block?: boolean; reason?: string };
+
+		assert.equal(blocked.block, true);
+		assert.match(blocked.reason ?? "", /foreign git config/);
+		assert.equal(harness.classifierCalls, 1);
+	} finally {
+		rmSync(base, { recursive: true, force: true });
+	}
+});
+
+test("statusText reports the permissions.allow rule count", () => {
+	const pattern = parseToolPattern("noop");
+	assert.ok(pattern);
+	const text = statusText(baseConfig({ permissionAllow: [pattern] }), baseState());
+	assert.match(text, /permissions\.allow rules: 1/);
 });
 
 test("classifyReadOnlyTools defaults to false", () => {
@@ -2794,6 +3041,27 @@ test("tool_call logs ccusage-compatible usage, classifier I/O, and decision", as
 			effectiveLevel: "high",
 		});
 		assert.deepEqual(decisionEntry.reasoning, classifierEntry.reasoning);
+	} finally {
+		rmSync(t.dir, { recursive: true, force: true });
+	}
+});
+
+test("/automode config reports the resolved permissions.allow rules", async () => {
+	const patterns = ["bash(git status*)", "example-extension-tool"].map((raw) =>
+		parseToolPattern(raw)!
+	);
+	const t = await setupLogTest({
+		config: baseConfig({ permissionAllow: patterns }),
+	});
+	try {
+		await t.fake.commands.get("automode")?.handler("config", t.ctx);
+		const notify = t.ctx.notifications.at(-1);
+		assert.ok(notify);
+		const parsed = JSON.parse(notify.message);
+		assert.deepEqual(
+			parsed.config.permissionAllow.map((pattern: { raw: string }) => pattern.raw),
+			patterns.map((pattern) => pattern.raw),
+		);
 	} finally {
 		rmSync(t.dir, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## What

Adds an opt-in `permissions.allow` list: a deterministic allow tier for tool calls that need no model review.

```json
"permissions": { "allow": ["bash(git status*)", "example-extension-tool"] }
```

Motivation: routine, side-effect-free calls (a narrowly scoped shell command, a read-only tool from another extension or an MCP server) currently cost a classifier call each. This lets a user opt those out, without touching the classifier policy itself.

## What it does not do

A match skips the classifier call and nothing else. The tier is evaluated after every deterministic barrier, so it can never turn a block into an allow:

1. `permissions.deny`
2. `permissions.ask` (a declined prompt still blocks)
3. deterministic hard-deny checks
4. path gate (`deniedPaths`, then the inside-working-directory tier)
5. **`permissions.allow`**
6. read-only built-in fast path
7. classifier

Additionally, `write`/`edit` whose resolved target is a protected path (`.git/hooks`, `.pi` controls, shell profiles, config files) are excluded from the tier and still reach the classifier — the same carve-out `allowInsideWorkingDirectory` uses.

Default is `[]`, so behavior is unchanged unless a user opts in.

## Config scopes

`allow` is read from every permission scope, exactly like `deny` and `ask`, shared project `.pi/automode.json` included. That is the one way a checked-in file can narrow classifier coverage, so it is called out explicitly in the README and in `docs/automode-classifier-flow.md`; the deterministic tiers still apply to those calls. If you would rather restrict `permissions.allow` to Pi-owned scopes only (global / `.pi/automode.local.json` / `PI_AUTOMODE_SETTINGS_JSON`), I am happy to change that — it is a one-line move in `buildEffectiveConfigFromSources`.

## Observability

- decision log entries use `kind: "permissions.allow"`;
- `/automode status` reports the rule count;
- `/automode config` prints the resolved patterns, along with the rest of the effective config.

## Docs

README, `docs/automode-classifier-flow.md` (flow list, mermaid diagram, config loading, new section), `docs/defaults.md`, `docs/GLOSSARY.md`, `docs/observability-logging.md`, `examples/automode.local.json`. The glossary and defaults docs now distinguish `autoMode.allow` (prose exceptions weighed by the classifier) from `permissions.allow` (patterns that skip the classifier).

One documented limitation: argument scoping only works for tools whose primary argument the matcher understands (`bash`, file tools, `grep`). For MCP and extension tools the argument pattern is compared against the serialized input, so the docs recommend bare tool names there. A test pins that behavior.

## Tests

Rebased on current `main`. `npm run check` and `npm test` pass (158 tests). New coverage: scope loading and validation diagnostics for `permissions.allow`; ordering guarantees (`deny` wins, hard-deny wins, `deniedPaths` wins); protected-path exclusion for in-tree writes and out-of-tree edits; argument scoping vs. bare-name matching; status line; `/automode config` reporting the resolved rules.

