### PR TITLE
fix: support OMP via legacy model registries

### DIFF
--- a/extensions/auto-mode/classifier.ts
+++ b/extensions/auto-mode/classifier.ts
@@ -1,9 +1,5 @@
 import { createHash } from "node:crypto";
 import { clampThinkingLevel } from "@earendil-works/pi-ai";
-import {
-  complete as compatComplete,
-  completeSimple as compatCompleteSimple,
-} from "@earendil-works/pi-ai/compat";
 import type {
   AssistantMessage,
   Model,
@@ -138,30 +134,57 @@ type RegistryCompletionApi = {
     ) => { result: () => Promise<AssistantMessage> };
   } | undefined;
 };
+type ClassifierCompletionFallbacks = {
+  rawComplete: ClassifierCompletionFn;
+  simpleComplete: ClassifierCompletionFn;
+};
+
+type ClassifierCompletionFallbackLoader =
+  () => Promise<ClassifierCompletionFallbacks>;
+
+// Static import would initialize deprecated compat registries on current Pi;
+// OMP rewrites this literal dynamic import to its native pi-ai module.
+async function loadCompatCompletionFns(): Promise<ClassifierCompletionFallbacks> {
+  const { complete, completeSimple } = await import(
+    "@earendil-works/pi-ai/compat"
+  );
+  return {
+    rawComplete: complete as ClassifierCompletionFn,
+    simpleComplete: completeSimple as ClassifierCompletionFn,
+  };
+}
 
 /**
  * Prefer the current runtime registry so extension-registered providers remain
  * visible. Older Pi-family runtimes (including OMP 18) expose neither
- * `complete` nor `getProvider`; fall back to the compat API they already use.
+ * `complete` nor `getProvider`; lazily load the compat API they already use.
  */
 export function createRegistryCompletionFns(
   registry: RegistryCompletionApi,
-  fallbackRaw: ClassifierCompletionFn = compatComplete,
-  fallbackSimple: ClassifierCompletionFn = compatCompleteSimple,
-): {
-  rawComplete: ClassifierCompletionFn;
-  simpleComplete: ClassifierCompletionFn;
-} {
+  fallbackLoader: ClassifierCompletionFallbackLoader =
+    loadCompatCompletionFns,
+): ClassifierCompletionFallbacks {
+  let fallbackPromise: Promise<ClassifierCompletionFallbacks> | undefined;
   const rawComplete: ClassifierCompletionFn =
     typeof registry.complete === "function"
       ? (model, context, options) =>
         registry.complete!.call(registry, model, context, options)
-      : fallbackRaw;
+      : async (model, context, options) =>
+        (await (fallbackPromise ??= fallbackLoader())).rawComplete(
+          model,
+          context,
+          options,
+        );
   const simpleComplete: ClassifierCompletionFn =
     typeof registry.getProvider === "function"
       ? (model, context, options) =>
         completeSimpleWithRegistry(registry, model, context, options)
-      : fallbackSimple;
+      : async (model, context, options) =>
+        (await (fallbackPromise ??= fallbackLoader())).simpleComplete(
+          model,
+          context,
+          options,
+        );
   return { rawComplete, simpleComplete };
 }
 

--- a/extensions/auto-mode/classifier.ts
+++ b/extensions/auto-mode/classifier.ts
@@ -1,5 +1,9 @@
 import { createHash } from "node:crypto";
 import { clampThinkingLevel } from "@earendil-works/pi-ai";
+import {
+  complete as compatComplete,
+  completeSimple as compatCompleteSimple,
+} from "@earendil-works/pi-ai/compat";
 import type {
   AssistantMessage,
   Model,
@@ -84,10 +88,9 @@ async function resolveClassifier(
     };
   }
 
-  const rawComplete: ClassifierCompletionFn = (callModel, context, options) =>
-    ctx.modelRegistry.complete(callModel, context, options);
-  const simpleComplete: ClassifierCompletionFn = (callModel, context, options) =>
-    completeSimpleWithRegistry(ctx, callModel, context, options);
+  const { rawComplete, simpleComplete } = createRegistryCompletionFns(
+    ctx.modelRegistry,
+  );
   const completionPlan = createClassifierCompletionPlan(
     model,
     config.classifierReasoningLevel,
@@ -125,6 +128,43 @@ export type ClassifierCompletionFn = (
   },
 ) => Promise<AssistantMessage>;
 
+type RegistryCompletionApi = {
+  complete?: ClassifierCompletionFn;
+  getProvider?: (provider: string) => {
+    streamSimple: (
+      model: Model<any>,
+      context: { systemPrompt: string; messages: UserMessage[] },
+      options: Parameters<ClassifierCompletionFn>[2],
+    ) => { result: () => Promise<AssistantMessage> };
+  } | undefined;
+};
+
+/**
+ * Prefer the current runtime registry so extension-registered providers remain
+ * visible. Older Pi-family runtimes (including OMP 18) expose neither
+ * `complete` nor `getProvider`; fall back to the compat API they already use.
+ */
+export function createRegistryCompletionFns(
+  registry: RegistryCompletionApi,
+  fallbackRaw: ClassifierCompletionFn = compatComplete,
+  fallbackSimple: ClassifierCompletionFn = compatCompleteSimple,
+): {
+  rawComplete: ClassifierCompletionFn;
+  simpleComplete: ClassifierCompletionFn;
+} {
+  const rawComplete: ClassifierCompletionFn =
+    typeof registry.complete === "function"
+      ? (model, context, options) =>
+        registry.complete!.call(registry, model, context, options)
+      : fallbackRaw;
+  const simpleComplete: ClassifierCompletionFn =
+    typeof registry.getProvider === "function"
+      ? (model, context, options) =>
+        completeSimpleWithRegistry(registry, model, context, options)
+      : fallbackSimple;
+  return { rawComplete, simpleComplete };
+}
+
 export type RetryOptions = {
   maxAttempts?: number;
   maxTokens?: number;
@@ -157,17 +197,16 @@ export type ClassifierCompletionPlan = {
 
 /**
  * Run normalized Pi AI completion through the provider in Pi's runtime registry.
- * This temporary bridge is only valid until Pi exposes
- * `ctx.modelRegistry.completeSimple(...)` natively. Replace this function with
- * that API when the project's minimum supported Pi version includes it.
+ * Callers use this only when the registry exposes `getProvider`; legacy
+ * registries take the compat completion path instead.
  */
 async function completeSimpleWithRegistry(
-  ctx: ExtensionContext,
+  registry: RegistryCompletionApi,
   model: Model<any>,
   context: { systemPrompt: string; messages: UserMessage[] },
   options: Parameters<ClassifierCompletionFn>[2],
 ): Promise<AssistantMessage> {
-  const provider = ctx.modelRegistry.getProvider(model.provider);
+  const provider = registry.getProvider?.(model.provider);
   if (!provider) throw new Error(`Unknown provider: ${model.provider}`);
   return provider.streamSimple(model, context, options).result();
 }

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -247,9 +247,10 @@ test("classifier completion plan preserves server default and clamps explicit le
 	});
 });
 
-test("legacy model registries use compat completion functions", async () => {
+test("legacy model registries lazy-load and cache compat completion functions", async () => {
 	const rawCalls: unknown[] = [];
 	const simpleCalls: unknown[] = [];
+	let loadCalls = 0;
 	const legacyRaw = async (...args: unknown[]) => {
 		rawCalls.push(args);
 		return assistantWith("0");
@@ -258,23 +259,24 @@ test("legacy model registries use compat completion functions", async () => {
 		simpleCalls.push(args);
 		return assistantWith("0");
 	};
-	const completions = createRegistryCompletionFns(
-		{},
-		legacyRaw as never,
-		legacySimple as never,
-	);
+	const completions = createRegistryCompletionFns({}, async () => {
+		loadCalls++;
+		return {
+			rawComplete: legacyRaw as never,
+			simpleComplete: legacySimple as never,
+		};
+	});
 
-	assert.equal(completions.rawComplete, legacyRaw);
-	assert.equal(completions.simpleComplete, legacySimple);
+	assert.equal(loadCalls, 0);
 	await completions.rawComplete({} as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 });
 	await completions.simpleComplete({} as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 });
+	assert.equal(loadCalls, 1);
 	assert.equal(rawCalls.length, 1);
 	assert.equal(simpleCalls.length, 1);
 });
 
-test("current model registries keep their runtime completion paths", async () => {
-	const rawFallback = async () => assistantWith("fallback");
-	const simpleFallback = async () => assistantWith("fallback");
+test("current model registries do not load compat completion functions", async () => {
+	let loadCalls = 0;
 	const provider = {
 		streamSimple: () => ({ result: async () => assistantWith("simple") }),
 	};
@@ -282,16 +284,17 @@ test("current model registries keep their runtime completion paths", async () =>
 		complete: async () => assistantWith("raw"),
 		getProvider: () => provider,
 	};
-	const completions = createRegistryCompletionFns(
-		registry,
-		rawFallback as never,
-		simpleFallback as never,
-	);
+	const completions = createRegistryCompletionFns(registry, async () => {
+		loadCalls++;
+		return {
+			rawComplete: async () => assistantWith("fallback"),
+			simpleComplete: async () => assistantWith("fallback"),
+		};
+	});
 
-	assert.notEqual(completions.rawComplete, rawFallback);
-	assert.notEqual(completions.simpleComplete, simpleFallback);
 	assert.equal((await completions.rawComplete({} as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 })).content[0]?.type, "text");
 	assert.equal((await completions.simpleComplete({ provider: "test" } as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 })).content[0]?.type, "text");
+	assert.equal(loadCalls, 0);
 });
 
 test("default classifier dispatches runtime-only models through the model registry", async () => {

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -11,6 +11,7 @@ import {
 	classifyInStages,
 	classifyWithRetry,
 	createClassifierCompletionPlan,
+	createRegistryCompletionFns,
 	createPiAutomode,
 	defaultClassifyAction,
 	parseClassifierDecision,
@@ -244,6 +245,53 @@ test("classifier completion plan preserves server default and clamps explicit le
 		requestedLevel: "low",
 		effectiveLevel: "off",
 	});
+});
+
+test("legacy model registries use compat completion functions", async () => {
+	const rawCalls: unknown[] = [];
+	const simpleCalls: unknown[] = [];
+	const legacyRaw = async (...args: unknown[]) => {
+		rawCalls.push(args);
+		return assistantWith("0");
+	};
+	const legacySimple = async (...args: unknown[]) => {
+		simpleCalls.push(args);
+		return assistantWith("0");
+	};
+	const completions = createRegistryCompletionFns(
+		{},
+		legacyRaw as never,
+		legacySimple as never,
+	);
+
+	assert.equal(completions.rawComplete, legacyRaw);
+	assert.equal(completions.simpleComplete, legacySimple);
+	await completions.rawComplete({} as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 });
+	await completions.simpleComplete({} as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 });
+	assert.equal(rawCalls.length, 1);
+	assert.equal(simpleCalls.length, 1);
+});
+
+test("current model registries keep their runtime completion paths", async () => {
+	const rawFallback = async () => assistantWith("fallback");
+	const simpleFallback = async () => assistantWith("fallback");
+	const provider = {
+		streamSimple: () => ({ result: async () => assistantWith("simple") }),
+	};
+	const registry = {
+		complete: async () => assistantWith("raw"),
+		getProvider: () => provider,
+	};
+	const completions = createRegistryCompletionFns(
+		registry,
+		rawFallback as never,
+		simpleFallback as never,
+	);
+
+	assert.notEqual(completions.rawComplete, rawFallback);
+	assert.notEqual(completions.simpleComplete, simpleFallback);
+	assert.equal((await completions.rawComplete({} as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 })).content[0]?.type, "text");
+	assert.equal((await completions.simpleComplete({ provider: "test" } as never, { systemPrompt: "", messages: [] }, { maxTokens: 1 })).content[0]?.type, "text");
 });
 
 test("default classifier dispatches runtime-only models through the model registry", async () => {


### PR DESCRIPTION
## Summary
- use the current runtime ModelRegistry completion APIs when they are available
- fall back to `@earendil-works/pi-ai/compat` completion functions on legacy Pi-family runtimes
- preserve runtime-only provider dispatch on current Pi
- cover both registry capability shapes with regression tests

## Problem

pi-automode 1.12+ assumes `ctx.modelRegistry.complete()` and `ctx.modelRegistry.getProvider()` exist. 
OhMyPi (OMP) 18 exposes neither method, so every classifier-routed tool call fails closed with:

```
Fast classifier failed; auto mode fails closed: ctx.modelRegistry.complete is not a function
```

The fallback restores the completion path used by pi-automode 1.11 only when those newer capabilities are absent.


## Verification

- `npm run check`
- `node --import tsx --test tests/classifier.test.ts` — 39 passed
- `npm pack --dry-run`
- fresh OMP 18 smoke test successfully classified and executed a `bash` call
